### PR TITLE
Moved karma modules from dev dependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,15 +45,15 @@
     "angular": "~1.4.3",
     "angular-ui-router": "~0.2.15",
     "path-parse": "~1.0.5",
-    "d3": "~3.5.6"
-  },
-  "devDependencies": {
-    "chai": "~3.2.0",
-    "mocha": "~2.2.5",
+    "d3": "~3.5.6",
     "del": "~1.2.0",
     "karma": "~0.13.8",
     "karma-mocha": "~0.2.0",
     "karma-chrome-launcher": "~0.2.0",
     "karma-browserify": "~4.3.0"
+  },
+  "devDependencies": {
+    "chai": "~3.2.0",
+    "mocha": "~2.2.5"
   }
 }


### PR DESCRIPTION
The reason is that the deployment script apparently needs karma in
production, which is super weird