### PR TITLE
Added role type to member profiles and all members list

### DIFF
--- a/server/memberController.js
+++ b/server/memberController.js
@@ -13,7 +13,7 @@ module.exports = {
     // parameter finds only current members of Congress in API request
     promiseGov.findRoleAsync({  current: true, 
                                 limit: 600, 
-                                fields: 'person__id,person__firstname,person__lastname,person__name' 
+                                fields: 'person__id,person__firstname,person__lastname,person__name,role_type' 
                               })
       .then(function(res){
         callback(res.objects);

--- a/server/utilController.js
+++ b/server/utilController.js
@@ -14,7 +14,8 @@ module.exports = {
       id: listing.person.id,
       firstName: listing.person.firstname,
       lastName: listing.person.lastname,
-      title: listing.person.name
+      title: listing.person.name,
+      role: listing.role_type
     };
   },
 
@@ -38,14 +39,15 @@ module.exports = {
       firstname: listing.firstname,
       lastname: listing.lastname,
       fullname: listing.name,
-      description: listing.roles[0].description,
-      party: listing.roles[0].party,
+      description: listing.roles[listing.roles.length - 1].description,
+      party: listing.roles[listing.roles.length - 1].party,
+      role: listing.roles[listing.roles.length - 1].role_type,
       birthday: listing.birthday,
-      enddate: listing.roles[0].enddate,
+      enddate: listing.roles[listing.roles.length - 1].enddate,
       twitterid: listing.twitterid,
       youtubeid: listing.youtubeid,
-      website: listing.roles[0].website,
-      phone: listing.roles[0].phone
+      website: listing.roles[listing.roles.length - 1].website,
+      phone: listing.roles[listing.roles.length - 1].phone
     };
   },
 


### PR DESCRIPTION
Also fixed bug in how we were pulling role information for each member profile
Previously I was grabbing the first entry, now I realize I had to grab the last entry to get
the most recent role info for members who have served multiple terms